### PR TITLE
Add audio codecs to alarm-clock configuration

### DIFF
--- a/alarm-clock-espidf.yaml
+++ b/alarm-clock-espidf.yaml
@@ -51,6 +51,13 @@ media_player:
     on_idle:
       - logger.log: "Playback finished!"
 
+audio:
+  codecs:
+    flac:
+    mp3:
+    opus:
+    wav:
+
 switch:
   - id: !extend alarm_on_local
     on_turn_off:


### PR DESCRIPTION
Added audio codecs support for flac, mp3, opus, and wav.